### PR TITLE
Require openssl

### DIFF
--- a/lib/shipping_easy.rb
+++ b/lib/shipping_easy.rb
@@ -2,6 +2,7 @@
 require "faraday"
 require "rack"
 require "json"
+require "openssl"
 require "shipping_easy/authenticator"
 require "shipping_easy/configuration"
 require "shipping_easy/signature"


### PR DESCRIPTION
If not required, library will trigger an exception: `uninitialized constant ShippingEasy::Signature::OpenSSL (NameError)` during configuration:

``` ruby
require "shipping_easy"

ShippingEasy.configure do |config|
  config.api_key    = "KEY"
  config.api_secret = "SECRET"
end
```

Did not test on all rubies, but this appears on MRI 2.1.2
