### PR TITLE
Stop modifying Signature input hashes

### DIFF
--- a/lib/shipping_easy/signature.rb
+++ b/lib/shipping_easy/signature.rb
@@ -19,11 +19,12 @@ module ShippingEasy
     #           :body - The body of the request which should normally be a JSON payload.
     #
     def initialize(options = {})
+      options = options.dup
       @api_secret = options.delete(:api_secret) || ""
       @method = options.fetch(:method, :get).to_s.upcase
       @path = options.delete(:path) || ""
       @body = options.delete(:body) || ""
-      @params = options.delete(:params) || {}
+      @params = options[:params].nil? ? {} : options.delete(:params).dup
       @params.delete(:api_signature) # remove for convenience
     end
 

--- a/spec/signature_spec.rb
+++ b/spec/signature_spec.rb
@@ -8,15 +8,35 @@ describe ShippingEasy::Signature do
   let(:request_body) { { orders: { name: "Flip flops", cost: "10.00", shipping_cost: "2.00" } }.to_json.to_s }
   let(:method) { :post }
 
-  subject { ShippingEasy::Signature.new(api_secret: api_secret, method: method, path: path, params: params, body: request_body) }
+  let(:options) { {api_secret: api_secret, method: method, path: path, params: params, body: request_body} }
+  subject { ShippingEasy::Signature.new(options) }
 
   describe "#initialize" do
     specify { subject.api_secret.should == api_secret }
     specify { subject.method.should == "POST" }
     specify { subject.path.should == path }
     specify { subject.body.should == request_body }
-    specify { subject.params.should == params }
     specify { subject.params[:api_signature].should be_nil }
+
+    it "does not modify the input hash" do
+      expect(subject).to_not be_nil
+      expect(options).to have_key(:api_secret)
+      expect(options).to have_key(:method)
+      expect(options).to have_key(:path)
+      expect(options).to have_key(:params)
+    end
+
+    it "does not modify the passed in params hash" do
+      expect(subject).to_not be_nil
+      expect(params).to have_key :test_param
+      expect(params).to have_key :api_key
+      expect(params).to have_key :api_signature
+    end
+
+    it "the exposed params hash does not contain the api_signature" do
+      params_without_signature = params.reject{|k,v| k == :api_signature}
+      expect(subject.params).to eq params_without_signature
+    end
   end
 
   describe "#plaintext" do


### PR DESCRIPTION
Callers would not expect their data to be modified, deleting keys is an implementation detail.