### PR TITLE
Follow redirects

### DIFF
--- a/lib/shipping_easy/configuration.rb
+++ b/lib/shipping_easy/configuration.rb
@@ -13,19 +13,29 @@
 #
 module ShippingEasy
   class Configuration
+    LEGACY_URL = "https://app.shippingeasy.com"
+    DEFAULT_URL = "https://api.shippingeasy.com"
 
+    attr_reader   :base_url
     attr_accessor :api_key,
                   :api_secret,
                   :partner_api_key,
                   :partner_api_secret,
                   :api_version,
-                  :base_url,
                   :http_adapter
 
     # Creates a configuration object, setting the default attributes.
     def initialize
       @http_adapter = ShippingEasy::Http::FaradayAdapter
-      @base_url = "https://app.shippingeasy.com"
+      @base_url = DEFAULT_URL
+    end
+
+    def base_url=(val)
+      if val == LEGACY_URL
+        @base_url = DEFAULT_URL
+      else
+        @base_url = val
+      end
     end
   end
 end

--- a/lib/shipping_easy/configuration.rb
+++ b/lib/shipping_easy/configuration.rb
@@ -32,6 +32,7 @@ module ShippingEasy
 
     def base_url=(val)
       if val == LEGACY_URL
+        warn "Legacy URL detected, updating to api.shippingeasy.com"
         @base_url = DEFAULT_URL
       else
         @base_url = val

--- a/lib/shipping_easy/http/faraday_adapter.rb
+++ b/lib/shipping_easy/http/faraday_adapter.rb
@@ -1,3 +1,4 @@
+require 'faraday_middleware'
 class ShippingEasy::Http::FaradayAdapter
 
   extend Forwardable
@@ -30,6 +31,7 @@ class ShippingEasy::Http::FaradayAdapter
 
   def connection
     @connection ||= Faraday.new(url: base_url) do |faraday|
+      faraday.use FaradayMiddleware::FollowRedirects, limit: 3, standards_compliant: true
       faraday.adapter Faraday.default_adapter
     end
   end

--- a/lib/shipping_easy/http/faraday_adapter.rb
+++ b/lib/shipping_easy/http/faraday_adapter.rb
@@ -32,8 +32,20 @@ class ShippingEasy::Http::FaradayAdapter
   def connection
     @connection ||= Faraday.new(url: base_url) do |faraday|
       faraday.use FaradayMiddleware::FollowRedirects, limit: 3, standards_compliant: true
+      faraday.use CustomUserAgent, "shipping_easy-ruby/#{ShippingEasy::VERSION}"
       faraday.adapter Faraday.default_adapter
     end
   end
+  
+  class CustomUserAgent < Faraday::Middleware
+    def initialize(app, agent_string)
+      super(app)
+      @agent_string = agent_string
+    end
 
+    def call(env)
+      env[:request_headers]['User-Agent'] = @agent_string
+      @app.call(env)
+    end
+  end
 end

--- a/lib/shipping_easy/http/request.rb
+++ b/lib/shipping_easy/http/request.rb
@@ -5,7 +5,7 @@ class ShippingEasy::Http::Request
   def initialize(options = {})
     @http_method = options.fetch(:http_method, :get)
     @params = options.fetch(:params, {})
-    @body = options.fetch(:payload, {}).to_json
+    @body = options[:payload] && options[:payload].to_json
     @relative_path = options.delete(:relative_path)
   end
 

--- a/lib/shipping_easy/version.rb
+++ b/lib/shipping_easy/version.rb
@@ -1,3 +1,3 @@
 module ShippingEasy
-  VERSION = "0.6.1"
+  VERSION = "0.7.0"
 end

--- a/shipping_easy.gemspec
+++ b/shipping_easy.gemspec
@@ -19,9 +19,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency('faraday', '>= 0.8.7')
+  spec.add_dependency('faraday_middleware', '>= 0.9.2')
   spec.add_dependency('rack', ">= 1.4.5")
   spec.add_dependency('json', "~> 1.8.0")
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "webmock"
   spec.add_development_dependency "rake"
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -20,12 +20,17 @@ describe ShippingEasy::Configuration do
 
   describe "base_url" do
     it "gets set to a default" do
-      subject.base_url.should == "https://app.shippingeasy.com"
+      subject.base_url.should == "https://api.shippingeasy.com"
     end
 
     it "can be overidden" do
       subject.base_url = String
       subject.base_url.should == String
+    end
+
+    it "ignores if set to the legacy URL" do
+      subject.base_url = "https://app.shippingeasy.com"
+      subject.base_url.should == "https://api.shippingeasy.com"
     end
   end
 end

--- a/spec/http/faraday_adapter_spec.rb
+++ b/spec/http/faraday_adapter_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require 'webmock/rspec'
 
 describe ShippingEasy::Http::FaradayAdapter do
 
@@ -39,4 +40,15 @@ describe ShippingEasy::Http::FaradayAdapter do
     end
   end
 
+  it "redirects, preserving method" do
+    stub_request(:post, "https://app.shippingeasy.com").to_return(
+      :status => 302,
+      :headers => {  "Location" => "https://app1.shippingeasy.com/" })
+    stub_request(:post, "https://app1.shippingeasy.com/")
+
+    response = subject.connection.post("https://app.shippingeasy.com")
+
+    expect(response.env[:method]).to eq(:post)
+    expect(response.env[:url].to_s).to eq("https://app1.shippingeasy.com/")
+  end
 end

--- a/spec/http/faraday_adapter_spec.rb
+++ b/spec/http/faraday_adapter_spec.rb
@@ -51,4 +51,10 @@ describe ShippingEasy::Http::FaradayAdapter do
     expect(response.env[:method]).to eq(:post)
     expect(response.env[:url].to_s).to eq("https://app1.shippingeasy.com/")
   end
+
+  it "adds a custom user agent" do
+    stub_request(:post, "https://app.shippingeasy.com")
+    response = subject.connection.post("https://app.shippingeasy.com")
+    expect(response.env.request_headers["User-Agent"]).to eq("shipping_easy-ruby/#{ShippingEasy::VERSION}")
+  end
 end

--- a/spec/http/faraday_adapter_spec.rb
+++ b/spec/http/faraday_adapter_spec.rb
@@ -42,7 +42,7 @@ describe ShippingEasy::Http::FaradayAdapter do
 
   it "redirects, preserving method" do
     stub_request(:post, "https://app.shippingeasy.com").to_return(
-      :status => 302,
+      :status => 307,
       :headers => {  "Location" => "https://app1.shippingeasy.com/" })
     stub_request(:post, "https://app1.shippingeasy.com/")
 

--- a/spec/http/request_spec.rb
+++ b/spec/http/request_spec.rb
@@ -9,7 +9,8 @@ describe ShippingEasy::Http::Request do
   let(:body) { { order_number: "1234" } }
   let(:api_key) { "12345678ASGHSGHJ" }
   let(:api_secret) { "12345678ASGHSGHJ123213321312" }
-  let(:signature) { ShippingEasy::Signature.new(api_secret: api_secret, method: http_method, path: "/api#{relative_path}", params: params.dup, body: body.to_json) }
+  let(:signed_body) { body && body.to_json }
+  let(:signature) { ShippingEasy::Signature.new(api_secret: api_secret, method: http_method, path: "/api#{relative_path}", params: params.dup, body: signed_body) }
 
   before do
     ShippingEasy.configure do |config|
@@ -46,6 +47,25 @@ describe ShippingEasy::Http::Request do
 
   describe "#signature" do
     it "returns a calculated sigature object" do
+      subject.signature.to_s.should == signature.to_s
+    end
+  end
+
+  describe 'body is nil for GET requests with nil body' do
+    let(:http_method) { "get" }
+    let(:body) { nil }
+    specify do
+      subject.body.should == nil
+      subject.signature.to_s.should == signature.to_s
+    end
+  end
+
+  describe 'body is nil for GET requests with omitted payload key' do
+    let(:http_method) { "get" }
+    let(:body) { nil }
+    subject { ShippingEasy::Http::Request.new(http_method: http_method, params: params, relative_path: relative_path) }
+    specify do
+      subject.body.should == nil
       subject.signature.to_s.should == signature.to_s
     end
   end


### PR DESCRIPTION
The API client does not currently follow redirects, which poses a problem for some architectural changes in the pipeline.  Include the `FollowRedirects` middleware, setting it up so that it will re-POST to the new endpoint on 302 instead of converting to GET.


Other changes:

-  Start including the library version in the user-agent header so it is possible to do feature detection.  The PHP library already does this.
-  Fix an issue where we were including a body of `{}` in HTTP GET requests, which broke redirection.  See the [commit](https://github.com/ShippingEasy/shipping_easy-ruby/pull/8/commits/50f537ba737676599991d4e7ca44d2b15ca6bf31) for more information.
- Start using the new `api.shippingeasy.com` as a default host (including an override if users try to use `app.shippingeasy.com`) for future infrastructure reasons.