### PR TITLE
Fix build: use different Gemfiles per ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 rvm:
-  - "1.9.3"
-  - "2.0.0"
-  - "2.1.2"
-  - "1.9.2"
-  - jruby-19mode
+  - "2.2.3"
+matrix:
+  include:
+    - rvm: "1.9.3"
+      gemfile: gemfiles/1.9.3-Gemfile
+    - rvm: "1.9.2"
+      gemfile: gemfiles/1.9.2-Gemfile
+    - rvm: "2.0.0"
+      gemfile: gemfiles/1.9.3-Gemfile
+    - rvm: "2.1.2"
+      gemfile: gemfiles/1.9.3-Gemfile
+    - rvm: jruby-19mode
+      gemfile: gemfiles/1.9.3-Gemfile

--- a/gemfiles/1.9.2-Gemfile
+++ b/gemfiles/1.9.2-Gemfile
@@ -1,0 +1,12 @@
+source "https://rubygems.org"
+
+gem 'faraday', '>= 0.8.7'
+gem 'faraday_middleware', '>= 0.9.2'
+gem 'rack', "1.4.5" # Need to lock rack to an old version for old rubies
+
+# dev dependencies
+gem 'json', "~> 1.8.0"
+gem "bundler", "~> 1.3"
+gem "rspec", "~> 3.0"
+gem "webmock", "1.24.6" # last version supported by 1.9.2
+gem "rake", "0.9.6" # last version supported by 1.9.2

--- a/gemfiles/1.9.3-Gemfile
+++ b/gemfiles/1.9.3-Gemfile
@@ -1,0 +1,12 @@
+source "https://rubygems.org"
+
+gem 'faraday', '>= 0.8.7'
+gem 'faraday_middleware', '>= 0.9.2'
+gem 'rack', "1.4.5" # Need to lock rack to an old version for old rubies
+
+# dev dependencies
+gem 'json', "~> 1.8.0"
+gem "bundler", "~> 1.3"
+gem "rspec", "~> 3.0"
+gem "webmock"
+gem "rake"

--- a/gemfiles/1.9.3-Gemfile.lock
+++ b/gemfiles/1.9.3-Gemfile.lock
@@ -1,0 +1,50 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.4.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.2.5)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.0)
+      faraday (>= 0.7.4, < 0.10)
+    hashdiff (0.3.0)
+    json (1.8.3)
+    multipart-post (2.0.0)
+    rack (1.4.5)
+    rake (11.2.2)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.1)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    safe_yaml (1.0.4)
+    webmock (2.1.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.3)
+  faraday (>= 0.8.7)
+  faraday_middleware (>= 0.9.2)
+  json (~> 1.8.0)
+  rack (= 1.4.5)
+  rake
+  rspec (~> 3.0)
+  webmock
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
The publicly visible build for our Ruby API client has been failing for a while.
The failures were caused by trying to use newer versions of gems that are not compatible with old ruby versions.