### PR TITLE
Relax json 1.x gem requirement to allow for Ruby 2.4.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,7 @@ matrix:
       gemfile: gemfiles/1.9.3-Gemfile
     - rvm: "2.1.2"
       gemfile: gemfiles/1.9.3-Gemfile
+    - rvm: "2.4.0"
+      gemfile: gemfiles/1.9.3-Gemfile
     - rvm: jruby-19mode
       gemfile: gemfiles/1.9.3-Gemfile

--- a/shipping_easy.gemspec
+++ b/shipping_easy.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('faraday', '>= 0.8.7')
   spec.add_dependency('faraday_middleware', '>= 0.9.2')
   spec.add_dependency('rack', ">= 1.4.5")
-  spec.add_dependency('json', "~> 1.8.0")
+  spec.add_dependency('json', ">= 1.8.0")
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock"


### PR DESCRIPTION
This was the only gem preventing me from updating my Ruby on Rails application to Rails 5 and  Ruby 2.4.0. By allowing for `json` 2.x gem compatibility, this will play nice while upgrading to the latest versions of Rails and Ruby. 

I added Ruby 2.4.0 to the travis config to ensure compatibility going forward. All specs passed locally.