### PR TITLE
Increase minimum required version of JSON

### DIFF
--- a/lib/shipping_easy/version.rb
+++ b/lib/shipping_easy/version.rb
@@ -1,3 +1,3 @@
 module ShippingEasy
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end

--- a/shipping_easy.gemspec
+++ b/shipping_easy.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('faraday', '>= 0.8.7')
   spec.add_dependency('faraday_middleware', '>= 0.9.2')
   spec.add_dependency('rack', ">= 1.4.5")
-  spec.add_dependency('json', ">= 1.8.0")
+  spec.add_dependency('json', ">= 2.3.0")
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock"


### PR DESCRIPTION
Increasing the required minimum version of JSON due to CVE:

CVE-2020-10663: Unsafe Object Creation Vulnerability in JSON (Additional fix)
https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/

Also increases version to 0.7.1 from 0.7.0.